### PR TITLE
main: check for default paths of the english translation folder.

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,13 +8,15 @@ import (
 	"path/filepath"
 
 	"github.com/XML-Comp/XML-Comp/comparer"
+	"os/user"
+	"runtime"
 )
 
 const ver = "v0.4"
 
 func main() {
 	var (
-		original            = flag.String("original", "", "Full path directory of your RimWorld English folder (required)")
+		original            = flag.String("original", getOriginalDir(), "Full path directory of your RimWorld English folder (required)")
 		translation         = flag.String("translation", "", "Full path directory of your RimWorld Translation folder (required)")
 		docType             = flag.String("doc", "xml", "Type of the Doc that you want to compare (not required)")
 		multipleMsg         = "Considers the translation flag as a collection of translations, enabling 1:N comparison"
@@ -66,4 +68,38 @@ func main() {
 	fmt.Println("Docs comparisons are DONE!")
 	fmt.Printf("Documents scanned: %v | Lines scanned: %v | Translations needed: %v\n", docs, lines, inNeed)
 	os.Exit(0)
+}
+
+// getOriginalDir gets the default Steam installation directory.
+// Returns empty string if directory is not found.
+func getOriginalDir() string {
+	rimWorldDir := ""
+
+	// https://support.steampowered.com/kb_article.php?ref=7710-tdlc-0426
+	if runtime.GOOS == "windows" && runtime.GOARCH == "386" {
+		rimWorldDir = `C:\Program Files\Steam\steamapps\common\RimWorld`
+	} else if runtime.GOOS == "windows" && runtime.GOARCH == "amd64" {
+		rimWorldDir = `C:\Program Files (x86)\Steam\steamapps\common\RimWorld`
+	} else if runtime.GOOS == "darwin" {
+		// https://gaming.stackexchange.com/a/219537
+		currentUser, err := user.Current()
+		if err != nil {
+			return ""
+		}
+
+		// safe to use *nix path sep since we are in the darwin runtime
+		rimWorldDir = filepath.Join(currentUser.HomeDir,
+			`/Library/Application Support/Steam/steamapps/common/RimWorld/RimWorldMac.app`)
+	}
+
+	// we're in all runtimes here, use os dependent separator
+	englishTrans := filepath.Join(rimWorldDir, "Mods", "Core", "Languages", "English")
+
+	// do one final check to make sure the English dir exists
+	_, err := os.Stat(englishTrans)
+	if err != nil {
+		englishTrans = ""
+	}
+
+	return englishTrans
 }


### PR DESCRIPTION
This function checks if the user is on Windows/Mac & which architecture
to find the Steam folder in. If the English Translation folder is not
found, the user must supply the -original argument.

**Note:** I do not have the game bought, so I used references of default Steam directory paths from [here](https://support.steampowered.com/kb_article.php?ref=7710-tdlc-0426) and [here](https://gaming.stackexchange.com/questions/78919/steam-mac-game-location/219537#219537).

I've also referenced the install paths for macOS in the [README#how-this-works](https://github.com/XML-Comp/XML-Comp/blob/master/README.md#how-this-works) section.

I've tested via manually placing folders in my steam directory.

**Note:** I do not have a Mac, so `darwin` has not been tested.
